### PR TITLE
Added event listeners to enable chosen select on creation of a new repeater

### DIFF
--- a/InputfieldChosenSelect.js
+++ b/InputfieldChosenSelect.js
@@ -9,5 +9,20 @@ $(document).ready(function() {
 		}
     if($t.not("[required]")) $t.children().first().text("");
 		$t.chosen(options); 
-	}); 
+	});
+
+    $(document).on('reloaded', '.InputfieldChosenSelect, .InputfieldPage', function() {
+        var $t = $(this);
+        if($t.hasClass('InputfieldPage')) $t = $t.find('.InputfieldChosenSelect');
+        if(!$t.length) return;
+        $(this).find("select").each(function() {
+            if(typeof config === 'undefined') {
+                var options = {};
+            } else {
+                var options = config[$t.attr('id')];
+            }
+            if($t.not("[required]")) $t.children().first().text("");
+            $t.chosen(options);
+        });
+    });
 }); 

--- a/InputfieldChosenSelectMultiple.js
+++ b/InputfieldChosenSelectMultiple.js
@@ -129,5 +129,32 @@ $(document).ready(function() {
     }else{
       $t.chosen(options).chosenSortable();
     }
-	}); 
+	});
+
+    $(document).on('reloaded', '.InputfieldChosenSelectMultiple, .InputfieldPage', function() {
+        var $t = $(this);
+        if($t.hasClass('InputfieldPage')) $t = $t.find('.InputfieldChosenSelectMultiple');
+        if(!$t.length) return;
+        $(this).find("select[multiple=multiple]").each(function() {
+            var $t = $(this),
+                $addable = $t.closest(".InputfieldChosenSelectMultiple").find(".InputfieldPageAdd");
+
+            if(typeof config === 'undefined') {
+                var options = { sortable: true };
+            } else {
+                var options = config[$t.attr('id')];
+            }
+
+            if($addable.length){
+                options["no_results_text"] = options["no_results_text_addable"];
+                $t.chosen(options).chosenSortable().chosenAddable();
+
+                if(!$t.data('chosen')){
+                    $addable.css("display", "block");
+                }
+            }else{
+                $t.chosen(options).chosenSortable();
+            }
+        });
+    });
 }); 


### PR DESCRIPTION
This fixes the bug where the chosen field is not rendered when used in a repeater field. The code is based on how the ASM select core module handles it.