### PR TITLE
add option for no result is found

### DIFF
--- a/InputfieldChosenSelect.module
+++ b/InputfieldChosenSelect.module
@@ -82,7 +82,8 @@ class InputfieldChosenSelect extends InputfieldSelect {
 
 		if(!$this->required) $this->setChosenOption('allow_single_deselect', 'true');
 		if($this->placeholder) $this->setChosenOption('placeholder_text_single', $this->placeholder);
-
+		if($this->noresult) $this->setChosenOption('no_results_text', $this->noresult);
+		
 		$this->config->js($this->id, $this->chosenOptions);
 
 		return parent::renderReady($parent, $renderValueMode);
@@ -124,6 +125,13 @@ class InputfieldChosenSelect extends InputfieldSelect {
 		$f->label = $this->_('Placeholder Text');
 		$f->description = $this->_('Placeholder-text to be displayed in empty field.'); 
 		$inputfields->add($f);
+		
+		$f = wire('modules')->get('InputfieldText');
+	    	$f->attr('name', 'noresult');
+	    	$f->attr('value', $this->noresult);
+	    	$f->label = $this->_('No result');
+	    	$f->description = $this->_('Message to display if no result is found.');
+	    	$inputfields->add($f);
 
 		return $inputfields;
 	}


### PR DESCRIPTION
Add an option to change the message that is displayed when no result is found.
This is good if you use this inputfield in backends with other languages than english.